### PR TITLE
Fix GC content on empty sequence

### DIFF
--- a/bioLOLPython/bio/sequence.py
+++ b/bioLOLPython/bio/sequence.py
@@ -8,9 +8,13 @@ class BioSeq:
         return str(self.seq.reverse_complement())
 
     def gc_content(self):
-        g = self.seq.count('G')
-        c = self.seq.count('C')
-        gc = (g + c) / len(self.seq) * 100
+        length = len(self.seq)
+        if length == 0:
+            gc = 0.0
+        else:
+            g = self.seq.count('G')
+            c = self.seq.count('C')
+            gc = (g + c) / length * 100
         return f"💥 GC content: {gc:.2f}% 🧬"
 
     def __str__(self):

--- a/tests/test_sequence.py
+++ b/tests/test_sequence.py
@@ -1,0 +1,7 @@
+import pytest
+from bioLOLPython.bio.sequence import BioSeq
+
+def test_gc_content_empty():
+    seq = BioSeq("")
+    assert seq.gc_content().startswith("💥 GC content: 0.00%")
+


### PR DESCRIPTION
## Summary
- handle empty sequences when calculating GC content
- add regression test for GC content helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842504c2874832da6945a1b66503390